### PR TITLE
Update hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
     "name": "Delete files and folders",
     "domains": ["delete"],
-    "render_readme": true
+    "render_readme": true,
+    "iot_class": ["Local Push"]
 }


### PR DESCRIPTION
Fixes an issue where HACS won't install the integration. HACS complains about a missing `manifest.json`. However that error is incorrect as it was missing the `iot_class` attribute inside of the `hacs.json` file. (I've already mentioned this on the HACS discord).
See: https://hacs.xyz/docs/publish/start/#hacsjson and then the attribute `iot_class` where it says that `iot_class` is only required for integrations.